### PR TITLE
Update ampinstmgr.service for docker

### DIFF
--- a/systemd/ampinstmgr.service
+++ b/systemd/ampinstmgr.service
@@ -3,6 +3,7 @@ Description=AMP Instance Manager
 Documentation=https://github.com/CubeCoders/AMP/wiki/AMP-systemd-script-(Linux)
 After=syslog.target
 After=network-online.target
+After=docker.service
 Wants=network-online.target
 PartOf=ampinstmgr.target
 


### PR DESCRIPTION
If docker.service is present, ampinstmgr.service should only start after docker.service is running. This way ampinstmgr.service is also stopped before docker.service is stopped on shutdown which allows a graceful stop.

This also helps to solve a part of issue #1019 